### PR TITLE
Avoid crop erase image when 0x0 dims

### DIFF
--- a/lib/image_processor.js
+++ b/lib/image_processor.js
@@ -43,6 +43,10 @@ module.exports = class ImageProcessor{
             var x = parseInt(data[3], 10) - 1;
             var y = parseInt(data[4], 10) - 1;
 
+            if(width === 0 && height === 0) {
+                return {width, height, x, y};
+            }
+
             if (width === 0 || height === 0) {
                 // precaution: never use 0x0 images
                 width = 1;


### PR DESCRIPTION
It's just to avoid doing the crop when image dimensions are 0x0. 

In Apple Silicon case, this PR allows to see the images, as all of them are calculated as 0x0.